### PR TITLE
API-1002: Adding JWT dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,23 @@
 			<artifactId>h2</artifactId>
 			<scope>runtime</scope>
 		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.11.5</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>0.11.5</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>0.11.5</version>
+			<scope>runtime</scope>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
Linking this PR to API-1002 to begin work on JWT authentication.
This commit adds the required `jjwt` library dependencies to enable JWT token creation and validation.

Closes #3